### PR TITLE
[#3] Feat ✨ Set Router Intro, Home, LogIn pages and header, footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,14 @@
-import "./App.css";
+import { HashRouter as Router } from "react-router-dom";
+import AppRouter from "./AppRouter";
 
 function App() {
-  return <>well-dying 프론트엔드</>;
+  return (
+    <div className="App">
+      <Router>
+        <AppRouter />
+      </Router>
+    </div>
+  );
 }
 
 export default App;

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -1,0 +1,26 @@
+import { FunctionComponent } from "react";
+import { Route, Routes } from "react-router-dom";
+import Home from "./pages/Home";
+import Intro from "./pages/Intro";
+import LogIn from "./pages/LogIn";
+import Header from "./components/common/Header";
+import Footer from "./components/common/Footer";
+type AppRouterProps = {};
+
+const AppRouter: FunctionComponent<AppRouterProps> = () => {
+  return (
+    <div>
+      <Header />
+      <main>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/intro" element={<Intro />} />
+          <Route path="/login" element={<LogIn />} />
+        </Routes>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default AppRouter;

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,0 +1,8 @@
+import { FunctionComponent } from "react";
+type FooterProps = {};
+
+const Footer: FunctionComponent<FooterProps> = () => {
+  return <footer>Footer</footer>;
+};
+
+export default Footer;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,8 @@
+import { FunctionComponent } from "react";
+type HeaderProps = {};
+
+const Header: FunctionComponent<HeaderProps> = () => {
+  return <header>Header</header>;
+};
+
+export default Header;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,8 @@
+import { FunctionComponent } from "react";
+type HomeProps = {};
+
+const Home: FunctionComponent<HomeProps> = () => {
+  return <div>Home</div>;
+};
+
+export default Home;

--- a/src/pages/Intro.tsx
+++ b/src/pages/Intro.tsx
@@ -1,0 +1,10 @@
+import { FunctionComponent } from 'react';
+type IntroProps = {};
+
+const Intro: FunctionComponent<IntroProps> = () => {
+  return (
+   <div>Intro</div>
+  );
+};
+
+export default Intro;

--- a/src/pages/LogIn.tsx
+++ b/src/pages/LogIn.tsx
@@ -1,0 +1,10 @@
+import { FunctionComponent } from 'react';
+type LogInProps = {};
+
+const LogIn: FunctionComponent<LogInProps> = () => {
+  return (
+   <div>LogIn</div>
+  );
+};
+
+export default LogIn;


### PR DESCRIPTION
`Intro`, `Home`, `LogIn` 페이지를 라우팅하고
공통 컴포넌트인 `header`와 `footer`를 위치하였습니다.

추후에 `header`, `footer` 가 필요하지 않을 경우, 새로운 `Router layout`를 생성할 수 있습니다.