### PR TITLE
[#14] Chore 🙈 Add vite pre-building file in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.vite/deps
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Dependency Pre-Bundling?
처음 vite를 실행할 때, Vite는 로컬에 사이트를 불러오기 전에 프로젝트의 디펜던시를 사전 번들링합니다. 
`.vite/deps` 폴더에 파일이 생성됩니다.

## Why?
이를 사용하는 목적은 다음과 같습니다.

### 1. CommonJS 그리고 UMD 모듈을 ESM으로 가져오기
개발 시, Vite의 개발 서버는 모든 코드를 네이티브 ESM으로 가져오게 됩니다. 따라서, vite는 반드시 모든 CommonJS 및 UMD 파일을 ESM으로 불러올 수 있도록 변환 작업을 진행해줘야 합니다. <br />
vite는 조금 영리하게 ESM 파일로 변환을 진행하는데, 가령 CommonJS 디펜던시를 변환해주는 경우 아래와 같이 이름을 지정해 CommonJS 형태의 모듈을 가져올 수도 있습니다.



### 2. 퍼포먼스
vite는 여러 디펜던시가 존재하는 ESM 모듈을 하나의 모듈로 변환하여 페이지 로드에 대한 퍼포먼스를 향상시킵니다. <br />
600개의 모듈을 갖고 있는 [lodash-es](https://unpkg.com/browse/lodash-es/)와 같이 매우 많은 모듈을 필요로 하는 경우, 그 수만큼 HTTP 요청을 전송하게 됩니다(import { debounce } from 'lodash-es'를 한다고 해도 말이죠). 서버가 이 요청들을 모두 정상적으로 처리한다고 해도, 브라우저 자체에서 이러한 네트워크 요청에 대한 오버헤드가 존재하기에 페이지 로드 퍼포먼스는 떨어질 수 밖에 없습니다. 즉, lodash-es 모듈을 가져오게 된다면... 600개의 HTTP 요청을 전송하게 되는 것이죠. <br />
만약 lodash-es 모듈을 하나의 모듈로 번들링하게 된다면 어떻게 될까요? 브라우저는 단지 하나의 HTTP 요청만을 전송하게 됩니다.


## commit을 해야할까?

pre-build 파일은 소스 코드에서 생성되는 파일입니다.
개발 환경에서 생성되는 것이므로, 갭라자 각각의 로컬 환경에서 다르게 생성될 수 있습니다.
따라서 `.gitignore` 파일에 추가하여 git 파일 추적을 제외합니다.


[Vite: 사전 번들링 된 디펜던시](https://vitejs-kr.github.io/guide/dep-pre-bundling.html)