### PR TITLE
[#36] Refactor: Move Intro Header component

### DIFF
--- a/src/components/Intro/Header.tsx
+++ b/src/components/Intro/Header.tsx
@@ -1,0 +1,23 @@
+import { FunctionComponent } from "react";
+import styled from "styled-components";
+type HeaderProps = {};
+
+const Header: FunctionComponent<HeaderProps> = () => {
+  return (
+    <HeaderContainer>
+      <HeaderImg src="public/Well-Dying.svg" alt="well dying" />
+    </HeaderContainer>
+  );
+};
+
+export default Header;
+
+const HeaderContainer = styled.header`
+  width: 100%;
+  padding: 13px 0;
+
+  display: flex;
+  justify-content: center;
+`;
+
+const HeaderImg = styled.img``;


### PR DESCRIPTION
공통 컴포넌트 폴더에 있던 Header 컴포넌트를 Intro 폴더로 이동합니다.