### PR TITLE
[#45] !HOTFIX: Remove parser babel option in prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,8 +4,7 @@
   "useTabs": false,
   "tabWidth": 2,
   "trailingComma": "all",
-  "printWidth": 80,
-  "parser": "babel",
+  "printWidth": 80,  
   "bracketSpacing": true,
   "arrowParens": "always"
 }


### PR DESCRIPTION
prettier 중 parser babel 옵션을 삭제합니다.
해당 옵션으로 인해 prettier 적용 시 useState() 코드가 잘못 정리되어 에러가 발생합니다.